### PR TITLE
Complete register.c file

### DIFF
--- a/src/registers.c
+++ b/src/registers.c
@@ -56,13 +56,13 @@ uint8_t registers_get_mode(registers r)
 {
   /*
     Modes :
-      USR 0x10
-      FIQ 0x11
-      IRQ 0x12
-      SVC 0x13
-      ABT 0x17
-      UND 0x1b
-      SYS 0x1f
+      USR 0x10 (User)
+      FIQ 0x11 (Fast Interrupt Request)
+      IRQ 0x12 (Interrupt Request)
+      SVC 0x13 (Supervisor)
+      ABT 0x17 (Abort)
+      UND 0x1b (Undefined)
+      SYS 0x1f (System)
     Documentation :
       https://developer.arm.com/documentation/ddi0406/cb/System-Level-Architecture/The-System-Level-Programmers--Model/ARM-processor-modes-and-ARM-core-registers/ARM-processor-modes?lang=en
   */
@@ -79,6 +79,14 @@ uint8_t registers_get_mode(registers r)
 
 static int registers_mode_has_spsr(registers r, uint8_t mode)
 {
+  /*
+  Dans l'architecture ARM, le registre SPSR (Saved Program Status Register) est un registre spécial qui sauvegarde l'état du registre CPSR (Current Program Status Register) lorsqu'une exception est déclenchée. Cela permet au processeur de restaurer l'état précédent du CPSR lorsque l'exception est terminée.
+
+  Cependant, le registre SPSR n'est pas toujours présent. Il n'existe que dans certains modes d'exécution du processeur. Plus précisément, il est présent dans les modes suivants : FIQ (Fast Interrupt Request), IRQ (Interrupt Request), SVC (Supervisor), ABT (Abort) et UND (Undefined).
+
+  Dire que le "registre SPSR est présent" signifie que le processeur est actuellement dans l'un de ces modes d'exécution où le registre SPSR existe et peut être utilisé.
+  */
+
   // Les modes qui ont un registre SPSR sont FIQ, IRQ, SVC, ABT et UND
   uint8_t modes_with_spsr[] = {FIQ, IRQ, SVC, ABT, UND};
 

--- a/src/registers.c
+++ b/src/registers.c
@@ -129,7 +129,7 @@ uint32_t registers_read(registers r, uint8_t reg, uint8_t mode)
     return r->registers[reg];
   }
 
-  // On regarde si le registre est un registre banked
+  // On regarde si le registre est un registre spécifique à un mode
   switch (mode)
   {
   case FIQ:
@@ -228,7 +228,94 @@ uint32_t registers_read_spsr(registers r, uint8_t mode)
 
 void registers_write(registers r, uint8_t reg, uint8_t mode, uint32_t value)
 {
-  return;
+  /*
+    Voir figure A2-1 du manuel (page 43)
+  */
+
+  // On regarde si le registre est un registre unbanked ou le pc (r15)
+  if (reg < 8 || reg == 15)
+  {
+    r->registers[reg] = value;
+    return;
+  }
+
+  // On regarde si le registre est un registre spécifique à un mode
+  switch (mode)
+  {
+  case FIQ:
+    switch (reg)
+    {
+    case 8:
+      r->r8_fiq = value;
+      return;
+    case 9:
+      r->r9_fiq = value;
+      return;
+    case 10:
+      r->r10_fiq = value;
+      return;
+    case 11:
+      r->r11_fiq = value;
+      return;
+    case 12:
+      r->r12_fiq = value;
+      return;
+    case 13:
+      r->r13_fiq = value;
+      return;
+    case 14:
+      r->r14_fiq = value;
+      return;
+    }
+    break;
+  case IRQ:
+    switch (reg)
+    {
+    case 13:
+      r->r13_irq = value;
+      return;
+    case 14:
+      r->r14_irq = value;
+      return;
+    }
+    break;
+  case SVC:
+    switch (reg)
+    {
+    case 13:
+      r->r13_svc = value;
+      return;
+    case 14:
+      r->r14_svc = value;
+      return;
+    }
+    break;
+  case ABT:
+    switch (reg)
+    {
+    case 13:
+      r->r13_abt = value;
+      return;
+    case 14:
+      r->r14_abt = value;
+      return;
+    }
+    break;
+  case UND:
+    switch (reg)
+    {
+    case 13:
+      r->r13_und = value;
+      return;
+    case 14:
+      r->r14_und = value;
+      return;
+    }
+    break;
+  }
+
+  // Le registre n'est pas un registre spécifique à un mode
+  r->registers[reg] = value;
 }
 
 void registers_write_cpsr(registers r, uint32_t value)

--- a/src/registers.c
+++ b/src/registers.c
@@ -27,8 +27,8 @@ Contact: Guillaume.Huard@imag.fr
 struct registers_data
 {
   uint32_t r[16];
-  uint32_t cpsr;    /* Current Program Status Register */
-  uint32_t spsr[5]; /* Saved Program Status Register */
+  uint32_t cpsr; /* Current Program Status Register */
+  uint32_t spsr; /* Saved Program Status Register */
 };
 
 registers registers_create()
@@ -63,6 +63,8 @@ uint8_t registers_get_mode(registers r)
       ABT 0x17
       UND 0x1b
       SYS 0x1f
+    Documentation :
+      https://developer.arm.com/documentation/ddi0406/cb/System-Level-Architecture/The-System-Level-Programmers--Model/ARM-processor-modes-and-ARM-core-registers/ARM-processor-modes?lang=en
   */
   if (r == NULL)
   {
@@ -77,7 +79,18 @@ uint8_t registers_get_mode(registers r)
 
 static int registers_mode_has_spsr(registers r, uint8_t mode)
 {
-  /* � compl�ter... */
+  // Les modes qui ont un registre SPSR sont FIQ, IRQ, SVC, ABT et UND
+  uint8_t modes_with_spsr[] = {FIQ, IRQ, SVC, ABT, UND};
+
+  // On retourne 1 si le mode est dans le tableau
+  for (int i = 0; i < sizeof(modes_with_spsr); i++)
+  {
+    if (mode == modes_with_spsr[i])
+    {
+      return 1;
+    }
+  }
+
   return 0;
 }
 

--- a/src/registers.c
+++ b/src/registers.c
@@ -28,7 +28,7 @@ struct registers_data
 {
   /*
     Registers :
-      r0-r10 (General Purpose)
+      r0-r7  (Unbanked Registers -> No special use)
       r11    (FP - Frame Pointer)
       r12    (IP - Intra Procedure Call)
       r13    (SP - Stack Pointer)
@@ -94,14 +94,11 @@ uint8_t registers_get_mode(registers r)
 static int registers_mode_has_spsr(registers r, uint8_t mode)
 {
   /*
-    Documentation:
-      https://developer.arm.com/documentation/dvi0027/b/arm-architecture-v4t/modes-and-exceptions
-
-      All modes other than User are privileged modes. These are used to service hardware interrupts, exceptions, and software interrupts. Each privileged mode has an associated Saved Program Status Register (SPSR). This register is use to save the state of the Current Program Status Register (CPSR) of the task immediately before the exception occurs.
+    Voir figure A2-1 du manuel (page 43)
   */
 
-  // On regarde si le mode est différent de USR
-  return mode != USR;
+  // On regarde si le mode appartient à la liste des modes qui ont un spsr
+  return mode == FIQ || mode == IRQ || mode == SVC || mode == ABT || mode == UND;
 }
 
 int registers_current_mode_has_spsr(registers r)
@@ -112,20 +109,17 @@ int registers_current_mode_has_spsr(registers r)
 int registers_in_a_privileged_mode(registers r)
 {
   /*
-    Documentation:
-      https://developer.arm.com/documentation/dvi0027/b/arm-architecture-v4t/modes-and-exceptions
-
-      All modes other than User are privileged modes. These are used to service hardware interrupts, exceptions, and software interrupts. Each privileged mode has an associated Saved Program Status Register (SPSR). This register is use to save the state of the Current Program Status Register (CPSR) of the task immediately before the exception occurs.
+    Voir figure A2-1 du manuel (page 43)
   */
 
-  // On regarde si le mode est différent de USR
-  return registers_get_mode(r) != USR;
+  // On regarde si le mode appartient à la liste des modes privilégiés
+  uint8_t mode = registers_get_mode(r);
+  return mode == FIQ || mode == IRQ || mode == SVC || mode == ABT || mode == UND || mode == SYS;
 }
 
 uint32_t registers_read(registers r, uint8_t reg, uint8_t mode)
 {
-  // TODO: Corriger cette fonction
-  return r->r[reg];
+  return 0;
 }
 
 uint32_t registers_read_cpsr(registers r)
@@ -135,7 +129,6 @@ uint32_t registers_read_cpsr(registers r)
 
 uint32_t registers_read_spsr(registers r, uint8_t mode)
 {
-  // On regarde si le mode est différent de USR
   if (registers_mode_has_spsr(r, mode))
   {
     return r->spsr;
@@ -149,8 +142,7 @@ uint32_t registers_read_spsr(registers r, uint8_t mode)
 
 void registers_write(registers r, uint8_t reg, uint8_t mode, uint32_t value)
 {
-  // TODO: Corriger cette fonction
-  r->r[reg] = value;
+  return;
 }
 
 void registers_write_cpsr(registers r, uint32_t value)
@@ -160,14 +152,5 @@ void registers_write_cpsr(registers r, uint32_t value)
 
 void registers_write_spsr(registers r, uint8_t mode, uint32_t value)
 {
-  // On regarde si le mode est différent de USR
-  if (registers_mode_has_spsr(r, mode))
-  {
-    r->spsr = value;
-  }
-  else
-  {
-    fprintf(stderr, "Erreur lors de l'écriture du registre spsr");
-    exit(EXIT_FAILURE);
-  }
+  return;
 }

--- a/src/registers.c
+++ b/src/registers.c
@@ -93,10 +93,6 @@ uint8_t registers_get_mode(registers r)
 
 static int registers_mode_has_spsr(registers r, uint8_t mode)
 {
-  /*
-    Voir figure A2-1 du manuel (page 43)
-  */
-
   // On regarde si le mode appartient à la liste des modes qui ont un spsr
   return mode == FIQ || mode == IRQ || mode == SVC || mode == ABT || mode == UND;
 }
@@ -108,10 +104,6 @@ int registers_current_mode_has_spsr(registers r)
 
 int registers_in_a_privileged_mode(registers r)
 {
-  /*
-    Voir figure A2-1 du manuel (page 43)
-  */
-
   // On regarde si le mode appartient à la liste des modes privilégiés
   uint8_t mode = registers_get_mode(r);
   return mode == FIQ || mode == IRQ || mode == SVC || mode == ABT || mode == UND || mode == SYS;
@@ -119,10 +111,6 @@ int registers_in_a_privileged_mode(registers r)
 
 uint32_t registers_read(registers r, uint8_t reg, uint8_t mode)
 {
-  /*
-    Voir figure A2-1 du manuel (page 43)
-  */
-
   // On regarde si le registre est un registre unbanked ou le pc (r15)
   if (reg < 8 || reg == 15)
   {
@@ -200,10 +188,6 @@ uint32_t registers_read_cpsr(registers r)
 
 uint32_t registers_read_spsr(registers r, uint8_t mode)
 {
-  /*
-    Voir figure A2-1 du manuel (page 43)
-  */
-
   // On regarde si le mode appartient à la liste des modes qui ont un spsr
   if (registers_mode_has_spsr(r, mode))
   {
@@ -228,10 +212,6 @@ uint32_t registers_read_spsr(registers r, uint8_t mode)
 
 void registers_write(registers r, uint8_t reg, uint8_t mode, uint32_t value)
 {
-  /*
-    Voir figure A2-1 du manuel (page 43)
-  */
-
   // On regarde si le registre est un registre unbanked ou le pc (r15)
   if (reg < 8 || reg == 15)
   {
@@ -325,5 +305,29 @@ void registers_write_cpsr(registers r, uint32_t value)
 
 void registers_write_spsr(registers r, uint8_t mode, uint32_t value)
 {
-  return;
+  // On regarde si le mode appartient à la liste des modes qui ont un spsr
+  if (registers_mode_has_spsr(r, mode))
+  {
+    switch (mode)
+    {
+    case FIQ:
+      r->spsr_fiq = value;
+      return;
+    case IRQ:
+      r->spsr_irq = value;
+      return;
+    case SVC:
+      r->spsr_svc = value;
+      return;
+    case ABT:
+      r->spsr_abt = value;
+      return;
+    case UND:
+      r->spsr_und = value;
+      return;
+    }
+  }
+
+  fprintf(stderr, "Erreur ! Le registre spsr n'existe pas pour le mode %s", arm_get_mode_name(mode));
+  exit(EXIT_FAILURE);
 }

--- a/src/registers.c
+++ b/src/registers.c
@@ -1,88 +1,129 @@
 /*
-Armator - simulateur de jeu d'instruction ARMv5T à but pédagogique
+Armator - simulateur de jeu d'instruction ARMv5T ï¿½ but pï¿½dagogique
 Copyright (C) 2011 Guillaume Huard
 Ce programme est libre, vous pouvez le redistribuer et/ou le modifier selon les
-termes de la Licence Publique Générale GNU publiée par la Free Software
-Foundation (version 2 ou bien toute autre version ultérieure choisie par vous).
+termes de la Licence Publique Gï¿½nï¿½rale GNU publiï¿½e par la Free Software
+Foundation (version 2 ou bien toute autre version ultï¿½rieure choisie par vous).
 
-Ce programme est distribué car potentiellement utile, mais SANS AUCUNE
+Ce programme est distribuï¿½ car potentiellement utile, mais SANS AUCUNE
 GARANTIE, ni explicite ni implicite, y compris les garanties de
-commercialisation ou d'adaptation dans un but spécifique. Reportez-vous à la
-Licence Publique Générale GNU pour plus de détails.
+commercialisation ou d'adaptation dans un but spï¿½cifique. Reportez-vous ï¿½ la
+Licence Publique Gï¿½nï¿½rale GNU pour plus de dï¿½tails.
 
-Vous devez avoir reçu une copie de la Licence Publique Générale GNU en même
-temps que ce programme ; si ce n'est pas le cas, écrivez à la Free Software
+Vous devez avoir reï¿½u une copie de la Licence Publique Gï¿½nï¿½rale GNU en mï¿½me
+temps que ce programme ; si ce n'est pas le cas, ï¿½crivez ï¿½ la Free Software
 Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307,
-États-Unis.
+ï¿½tats-Unis.
 
 Contact: Guillaume.Huard@imag.fr
-	 Bâtiment IMAG
-	 700 avenue centrale, domaine universitaire
-	 38401 Saint Martin d'Hères
+   Bï¿½timent IMAG
+   700 avenue centrale, domaine universitaire
+   38401 Saint Martin d'Hï¿½res
 */
 #include "registers.h"
 #include "arm_constants.h"
 #include <stdlib.h>
 
-struct registers_data {
-    /* À compléter... */
+struct registers_data
+{
+  uint32_t r[16];
+  uint32_t cpsr;    /* Current Program Status Register */
+  uint32_t spsr[5]; /* Saved Program Status Register */
 };
 
-registers registers_create() {
-    registers r = NULL;
-    /* À compléter... */
-    return r;
+registers registers_create()
+{
+  registers registers = malloc(sizeof(struct registers_data));
+
+  if (registers == NULL)
+  {
+    ERROR_MSG("Erreur lors de l'allocation des registres");
+    exit(EXIT_FAILURE);
+  }
+
+  return registers;
 }
 
-void registers_destroy(registers r) {
-    /* À compléter... */
+void registers_destroy(registers r)
+{
+  if (r != NULL)
+  {
+    free(r);
+  }
 }
 
-uint8_t registers_get_mode(registers r) {
-    /* À compléter... */
-    return SVC;
+uint8_t registers_get_mode(registers r)
+{
+  /*
+    Modes :
+      USR 0x10
+      FIQ 0x11
+      IRQ 0x12
+      SVC 0x13
+      ABT 0x17
+      UND 0x1b
+      SYS 0x1f
+  */
+  if (r == NULL)
+  {
+    ERROR_MSG("Erreur lors de la lecture du mode");
+    exit(EXIT_FAILURE);
+  }
+  // On regarde les 5 derniers bits de poids faible du registre cpsr
+  // Pour rÃ©cupÃ©rer le mode
+  // 0x1f = 0001 1111
+  return r->cpsr & 0x1f;
 }
 
-static int registers_mode_has_spsr(registers r, uint8_t mode) {
-    /* À compléter... */
-    return 1;
+static int registers_mode_has_spsr(registers r, uint8_t mode)
+{
+  /* ï¿½ complï¿½ter... */
+  return 0;
 }
 
-int registers_current_mode_has_spsr(registers r) {
-    return registers_mode_has_spsr(r, registers_get_mode(r));
+int registers_current_mode_has_spsr(registers r)
+{
+  return registers_mode_has_spsr(r, registers_get_mode(r));
 }
 
-int registers_in_a_privileged_mode(registers r) {
-    /* À compléter... */
-    return 0;
+int registers_in_a_privileged_mode(registers r)
+{
+  /* ï¿½ complï¿½ter... */
+  return 0;
 }
 
-uint32_t registers_read(registers r, uint8_t reg, uint8_t mode) {
-    uint32_t value = 0;
-    /* À compléter... */
-    return value;
+uint32_t registers_read(registers r, uint8_t reg, uint8_t mode)
+{
+  uint32_t value = 0;
+  /* ï¿½ complï¿½ter... */
+  return value;
 }
 
-uint32_t registers_read_cpsr(registers r) {
-    uint32_t value = 0;
-    /* À compléter... */
-    return value;
+uint32_t registers_read_cpsr(registers r)
+{
+  uint32_t value = 0;
+  /* ï¿½ complï¿½ter... */
+  return value;
 }
 
-uint32_t registers_read_spsr(registers r, uint8_t mode) {
-    uint32_t value = 0;
-    /* À compléter... */
-    return value;
+uint32_t registers_read_spsr(registers r, uint8_t mode)
+{
+  uint32_t value = 0;
+  /* ï¿½ complï¿½ter... */
+  return value;
 }
 
-void registers_write(registers r, uint8_t reg, uint8_t mode, uint32_t value) {
-    /* À compléter... */
+void registers_write(registers r, uint8_t reg, uint8_t mode, uint32_t value)
+{
+  /* ï¿½ complï¿½ter... */
 }
 
-void registers_write_cpsr(registers r, uint32_t value) {
-    /* À compléter... */
+void registers_write_cpsr(registers r, uint32_t value)
+{
+  /* ï¿½ complï¿½ter... */
 }
 
-void registers_write_spsr(registers r, uint8_t mode, uint32_t value) {
-    /* À compléter... */
+void registers_write_spsr(registers r, uint8_t mode, uint32_t value)
+{
+  /* ï¿½ complï¿½ter... */
 }

--- a/src/registers.c
+++ b/src/registers.c
@@ -63,6 +63,7 @@ uint8_t registers_get_mode(registers r)
       ABT 0x17 (Abort)
       UND 0x1b (Undefined)
       SYS 0x1f (System)
+
     Documentation :
       https://developer.arm.com/documentation/ddi0406/cb/System-Level-Architecture/The-System-Level-Programmers--Model/ARM-processor-modes-and-ARM-core-registers/ARM-processor-modes?lang=en
   */
@@ -80,26 +81,14 @@ uint8_t registers_get_mode(registers r)
 static int registers_mode_has_spsr(registers r, uint8_t mode)
 {
   /*
-  Dans l'architecture ARM, le registre SPSR (Saved Program Status Register) est un registre spécial qui sauvegarde l'état du registre CPSR (Current Program Status Register) lorsqu'une exception est déclenchée. Cela permet au processeur de restaurer l'état précédent du CPSR lorsque l'exception est terminée.
+    Documentation:
+      https://developer.arm.com/documentation/dvi0027/b/arm-architecture-v4t/modes-and-exceptions
 
-  Cependant, le registre SPSR n'est pas toujours présent. Il n'existe que dans certains modes d'exécution du processeur. Plus précisément, il est présent dans les modes suivants : FIQ (Fast Interrupt Request), IRQ (Interrupt Request), SVC (Supervisor), ABT (Abort) et UND (Undefined).
-
-  Dire que le "registre SPSR est présent" signifie que le processeur est actuellement dans l'un de ces modes d'exécution où le registre SPSR existe et peut être utilisé.
+      All modes other than User are privileged modes. These are used to service hardware interrupts, exceptions, and software interrupts. Each privileged mode has an associated Saved Program Status Register (SPSR). This register is use to save the state of the Current Program Status Register (CPSR) of the task immediately before the exception occurs.
   */
 
-  // Les modes qui ont un registre SPSR sont FIQ, IRQ, SVC, ABT et UND
-  uint8_t modes_with_spsr[] = {FIQ, IRQ, SVC, ABT, UND};
-
-  // On retourne 1 si le mode est dans le tableau
-  for (int i = 0; i < sizeof(modes_with_spsr); i++)
-  {
-    if (mode == modes_with_spsr[i])
-    {
-      return 1;
-    }
-  }
-
-  return 0;
+  // On regarde si le mode est différent de USR
+  return mode != USR;
 }
 
 int registers_current_mode_has_spsr(registers r)
@@ -109,8 +98,15 @@ int registers_current_mode_has_spsr(registers r)
 
 int registers_in_a_privileged_mode(registers r)
 {
-  /* � compl�ter... */
-  return 0;
+  /*
+    Documentation:
+      https://developer.arm.com/documentation/dvi0027/b/arm-architecture-v4t/modes-and-exceptions
+
+      All modes other than User are privileged modes. These are used to service hardware interrupts, exceptions, and software interrupts. Each privileged mode has an associated Saved Program Status Register (SPSR). This register is use to save the state of the Current Program Status Register (CPSR) of the task immediately before the exception occurs.
+  */
+
+  // On regarde si le mode est différent de USR
+  return registers_get_mode(r) != USR;
 }
 
 uint32_t registers_read(registers r, uint8_t reg, uint8_t mode)

--- a/src/registers.c
+++ b/src/registers.c
@@ -200,7 +200,30 @@ uint32_t registers_read_cpsr(registers r)
 
 uint32_t registers_read_spsr(registers r, uint8_t mode)
 {
-  return 0;
+  /*
+    Voir figure A2-1 du manuel (page 43)
+  */
+
+  // On regarde si le mode appartient à la liste des modes qui ont un spsr
+  if (registers_mode_has_spsr(r, mode))
+  {
+    switch (mode)
+    {
+    case FIQ:
+      return r->spsr_fiq;
+    case IRQ:
+      return r->spsr_irq;
+    case SVC:
+      return r->spsr_svc;
+    case ABT:
+      return r->spsr_abt;
+    case UND:
+      return r->spsr_und;
+    }
+  }
+
+  fprintf(stderr, "Erreur ! Le registre spsr n'existe pas pour le mode %s", arm_get_mode_name(mode));
+  exit(EXIT_FAILURE);
 }
 
 void registers_write(registers r, uint8_t reg, uint8_t mode, uint32_t value)

--- a/src/registers.c
+++ b/src/registers.c
@@ -26,9 +26,22 @@ Contact: Guillaume.Huard@imag.fr
 
 struct registers_data
 {
+  /*
+    Registers :
+      r0-r10 (General Purpose)
+      r11    (FP - Frame Pointer)
+      r12    (IP - Intra Procedure Call)
+      r13    (SP - Stack Pointer)
+      r14    (LR - Link Register)
+      r15    (PC - Program Counter)
+      cpsr   (CPSR - Current Program Status Register)
+      spsr   (SPSR - Saved Program Status Register)
+    Tutorial :
+      https://www.youtube.com/watch?v=ibh4tadjUaw&ab_channel=techAj
+  */
   uint32_t r[16];
-  uint32_t cpsr; /* Current Program Status Register */
-  uint32_t spsr; /* Saved Program Status Register */
+  uint32_t cpsr;
+  uint32_t spsr;
 };
 
 registers registers_create()
@@ -37,7 +50,7 @@ registers registers_create()
 
   if (registers == NULL)
   {
-    ERROR_MSG("Erreur lors de l'allocation des registres");
+    fprintf(stderr, "Erreur lors de l'allocation des registres");
     exit(EXIT_FAILURE);
   }
 
@@ -69,7 +82,7 @@ uint8_t registers_get_mode(registers r)
   */
   if (r == NULL)
   {
-    ERROR_MSG("Erreur lors de la lecture du mode");
+    fprintf(stderr, "Erreur lors de la lecture du mode");
     exit(EXIT_FAILURE);
   }
   // On regarde les 5 derniers bits de poids faible du registre cpsr
@@ -111,36 +124,50 @@ int registers_in_a_privileged_mode(registers r)
 
 uint32_t registers_read(registers r, uint8_t reg, uint8_t mode)
 {
-  uint32_t value = 0;
-  /* � compl�ter... */
-  return value;
+  // TODO: Corriger cette fonction
+  return r->r[reg];
 }
 
 uint32_t registers_read_cpsr(registers r)
 {
-  uint32_t value = 0;
-  /* � compl�ter... */
-  return value;
+  return r->cpsr;
 }
 
 uint32_t registers_read_spsr(registers r, uint8_t mode)
 {
-  uint32_t value = 0;
-  /* � compl�ter... */
-  return value;
+  // On regarde si le mode est différent de USR
+  if (registers_mode_has_spsr(r, mode))
+  {
+    return r->spsr;
+  }
+  else
+  {
+    fprintf(stderr, "Erreur lors de la lecture du registre spsr");
+    exit(EXIT_FAILURE);
+  }
 }
 
 void registers_write(registers r, uint8_t reg, uint8_t mode, uint32_t value)
 {
-  /* � compl�ter... */
+  // TODO: Corriger cette fonction
+  r->r[reg] = value;
 }
 
 void registers_write_cpsr(registers r, uint32_t value)
 {
-  /* � compl�ter... */
+  r->cpsr = value;
 }
 
 void registers_write_spsr(registers r, uint8_t mode, uint32_t value)
 {
-  /* � compl�ter... */
+  // On regarde si le mode est différent de USR
+  if (registers_mode_has_spsr(r, mode))
+  {
+    r->spsr = value;
+  }
+  else
+  {
+    fprintf(stderr, "Erreur lors de l'écriture du registre spsr");
+    exit(EXIT_FAILURE);
+  }
 }

--- a/src/registers.c
+++ b/src/registers.c
@@ -28,22 +28,23 @@ struct registers_data
 {
   /*
     Voir figure A2-1 du manuel (page 43)
-  */
-  // r0-r7 sont les mêmes pour tous les modes (unbanked registers)
-  uint32_t unbanked_registers[8];
 
-  // r15 (pc) est le même pour tous les modes
-  uint32_t pc;
+    Video: https://youtu.be/msWvVmCZRTI?si=YUxaf2tEL0ttMTFD
+  */
+
+  // r0-r7 sont les mêmes pour tous les modes (unbanked registers)
+  // pc est le même pour tous les modes (r15)
+  uint32_t unbanked_registers[16];
+
+  // Modes spécifiques de SVC, ABT, UND, IRQ, FIQ
+  uint32_t r13_svc, r14_svc, spsr_svc;
+  uint32_t r13_abt, r14_abt, spsr_abt;
+  uint32_t r13_und, r14_und, spsr_und;
+  uint32_t r13_irq, r14_irq, spsr_irq;
+  uint32_t r8_fiq, r9_fiq, r10_fiq, r11_fiq, r12_fiq, r13_fiq, r14_fiq;
 
   // cpsr est le même pour tous les modes
   uint32_t cpsr;
-
-  // Les 5 modes qui ont un spsr ont un spsr différent
-  uint32_t spsr_svc;
-  uint32_t spsr_abt;
-  uint32_t spsr_und;
-  uint32_t spsr_irq;
-  uint32_t spsr_fiq;
 };
 
 registers registers_create()

--- a/src/registers.c
+++ b/src/registers.c
@@ -27,21 +27,23 @@ Contact: Guillaume.Huard@imag.fr
 struct registers_data
 {
   /*
-    Registers :
-      r0-r7  (Unbanked Registers -> No special use)
-      r11    (FP - Frame Pointer)
-      r12    (IP - Intra Procedure Call)
-      r13    (SP - Stack Pointer)
-      r14    (LR - Link Register)
-      r15    (PC - Program Counter)
-      cpsr   (CPSR - Current Program Status Register)
-      spsr   (SPSR - Saved Program Status Register)
-    Tutorial :
-      https://www.youtube.com/watch?v=ibh4tadjUaw&ab_channel=techAj
+    Voir figure A2-1 du manuel (page 43)
   */
-  uint32_t r[16];
+  // r0-r7 sont les mêmes pour tous les modes (unbanked registers)
+  uint32_t unbanked_registers[8];
+
+  // r15 (pc) est le même pour tous les modes
+  uint32_t pc;
+
+  // cpsr est le même pour tous les modes
   uint32_t cpsr;
-  uint32_t spsr;
+
+  // Les 5 modes qui ont un spsr ont un spsr différent
+  uint32_t spsr_svc;
+  uint32_t spsr_abt;
+  uint32_t spsr_und;
+  uint32_t spsr_irq;
+  uint32_t spsr_fiq;
 };
 
 registers registers_create()


### PR DESCRIPTION
Struct :
struct registers_data
{
  /*
    Voir figure A2-1 du manuel (page 43)

    Video: https://youtu.be/msWvVmCZRTI?si=YUxaf2tEL0ttMTFD
  */

  // r0-r7 sont les mêmes pour tous les modes (unbanked registers)
  // pc est le même pour tous les modes (r15)
  uint32_t registers[16];

  // Modes spécifiques de SVC, ABT, UND, IRQ, FIQ
  uint32_t r13_svc, r14_svc, spsr_svc;
  uint32_t r13_abt, r14_abt, spsr_abt;
  uint32_t r13_und, r14_und, spsr_und;
  uint32_t r13_irq, r14_irq, spsr_irq;
  uint32_t r8_fiq, r9_fiq, r10_fiq, r11_fiq, r12_fiq, r13_fiq, r14_fiq, spsr_fiq;

  // cpsr est le même pour tous les modes
  uint32_t cpsr;
};